### PR TITLE
Issue #3: Fix PHP 8.1 deprecation warnings on implicit cast to int.

### DIFF
--- a/libraries/PHPExcel/Classes/PHPExcel/Cell.php
+++ b/libraries/PHPExcel/Classes/PHPExcel/Cell.php
@@ -842,11 +842,11 @@ class PHPExcel_Cell
             if ($pColumnIndex < 26) {
                 $_indexCache[$pColumnIndex] = chr(65 + $pColumnIndex);
             } elseif ($pColumnIndex < 702) {
-                $_indexCache[$pColumnIndex] = chr(64 + ($pColumnIndex / 26)) .
+                $_indexCache[$pColumnIndex] = chr(64 + (int) ($pColumnIndex / 26)) .
                                               chr(65 + $pColumnIndex % 26);
             } else {
-                $_indexCache[$pColumnIndex] = chr(64 + (($pColumnIndex - 26) / 676)) .
-                                              chr(65 + ((($pColumnIndex - 26) % 676) / 26)) .
+                $_indexCache[$pColumnIndex] = chr(64 + (int) (($pColumnIndex - 26) / 676)) .
+                                              chr(65 + (int) ((($pColumnIndex - 26) % 676) / 26)) .
                                               chr(65 + $pColumnIndex % 26);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/phpexcel/issues/3.